### PR TITLE
Feat: revert the main if statement logic 

### DIFF
--- a/goldens/Cluster_create_with_gb200-4.txt
+++ b/goldens/Cluster_create_with_gb200-4.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py cluster create --project=golden-project --zone=us-central1-a --cluster=golden-cluster --device-type=gb200-4 --reservation=golden-reservation --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Starting cluster create for cluster golden-cluster:
 [XPK] Working on golden-project and us-central1-a
 [XPK] Task: `Determine server supported GKE versions for default rapid gke version` is implemented by the following command not running since it is a dry run. 

--- a/src/xpk/main.py
+++ b/src/xpk/main.py
@@ -67,11 +67,11 @@ def main() -> None:
   main_args = parser.parse_args()
   main_args.enable_ray_cluster = False
   set_dry_run('dry_run' in main_args and main_args.dry_run)
-  if not main_args.dry_run and not main_args.skip_validation:
+  if main_args.dry_run or main_args.skip_validation:
+    xpk_print('Skipping dependency validation.', flush=True)
+  else:
     xpk_print('Validating dependencies...', flush=True)
     validate_dependencies()
-  else:
-    xpk_print('Skipping dependency validation.', flush=True)
   main_args.func(main_args)
   xpk_print('XPK Done.', flush=True)
 


### PR DESCRIPTION
## Background
Our Airflow integration tests only use `workload create` and `create-pathway` commands. We do not require system dependencies like `docker` or `kubectl-kjob` to launch these workloads.

Installing these non-essential tools in the Airflow/Composer environment introduces significant complexity and workarounds (refer to b/411426745)

## Fixes / Features
- Modified the main execution flow in `src/xpk/main.py` to check for the `skip_validation` flag; validation is skipped with a corresponding message if the flag is set.

## Testing / Documentation
- The changes were tested by running workload creation commands that use a custom Docker image in Airflow. The tests confirm that validation is now successfully skipped in this scenario, allowing the commands to run without error.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
